### PR TITLE
feat: add home manager options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,28 @@ in
 }
 ```
 
+If you prefer homeManager.
+
+```nix
+{
+  home-manager.users."<your-username>" = {
+    imports = [
+      inputs.nfsm-flake.homeModules.default
+    ];
+     
+    # `default` means the value is the default value.
+    # This option creates a systemd service for daemon
+    services.nfsm = {
+      enable = true;
+      package = inputs.nfsm-flake.packages.${system}.nfsm; # default
+      enableCli = true; # default
+      cliPackage = inputs.nfsm-flake.packages.${system}.nfsm-cli; # default
+      socketPath = "/run/user/1000/nfsm.sock"; # default
+    };
+  }
+};
+```
+
 Only available for Linux systems; run `nix flake show` to see all outputs.
 
 If Nix is not your jam, you can grab the [daemon script](./src/nfsm.py) file directly and give it execution permissions (`chmod +x nfsm.py`). The client script can be found [here](./src/cli.nix).

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     };
   };
 
-  outputs = { nixpkgs, flake-utils, ... }:
+  outputs = { self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         nfsm-overlay = f: p: {
@@ -31,5 +31,8 @@
           default = pkgs.nfsm;
         };
       }
-    );
+    )
+    // {
+      homeModules.default = import ./hm-module.nix self;
+    };
 }

--- a/hm-module.nix
+++ b/hm-module.nix
@@ -1,0 +1,61 @@
+self:
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+let
+  inherit (lib)
+    mkOption
+    mkEnableOption
+    mkIf
+    types
+    getExe'
+    ;
+  inherit (pkgs.stdenv.hostPlatform) system;
+  inherit (self.packages.${system}) nfsm nfsm-cli;
+
+  cfg = config.services.nfsm;
+in
+{
+  options.services.nfsm = {
+    enable = mkEnableOption "Fullscreen manager for niri";
+    package = mkOption {
+      type = types.package;
+      default = nfsm;
+      description = "nfsm package to use";
+    };
+    cliPackage = mkOption {
+      type = types.package;
+      default = nfsm-cli;
+      description = "nfsm-cli package to use";
+    };
+    enableCli = (mkEnableOption "Install nfsm-cli to system") // {
+      default = true;
+    };
+    socketPath = mkOption {
+      type = types.str;
+      default = "/run/user/1000/nfsm.sock";
+      description = "Will open a Unix Socket under this path. This value will set `NFSM_SOCKET` environment variable.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.user.services.nfsm = {
+      Install = {
+        WantedBy = [ "graphical-session.target" ];
+      };
+      Service = {
+        ExecStart = "${getExe' cfg.package "nfsm"}";
+        Environment = [
+          "NFSM_SOCKET=${cfg.socketPath}"
+        ];
+      };
+    };
+
+    home.packages = mkIf cfg.enableCli [
+      cfg.cliPackage
+    ];
+  };
+}


### PR DESCRIPTION
Hey, thanks a lot for all the work on this project! It's been super helpful.

I added Home Manager support so users can install and configure `nfsm` more easily. 

Changes:
- Add Home Manager option.
- Document Home Manager usage in `README.md`.