### PR TITLE
Support `maximize-to-window-edges`

### DIFF
--- a/hm-module.nix
+++ b/hm-module.nix
@@ -51,6 +51,8 @@ in
         Environment = [
           "NFSM_SOCKET=${cfg.socketPath}"
         ];
+        Restart = "on-failure";
+        RestartSec = "1";
       };
     };
 

--- a/src/cli.nix
+++ b/src/cli.nix
@@ -8,21 +8,25 @@ writeShellApplication {
   runtimeInputs = [ libnotify socat ];
   text = ''
     SOCKET=''${NFSM_SOCKET:-/run/user/1000/nfsm.sock}
-    trap 'notify-send --icon="${./assets/icon.png}" --app-name="NFSM" "Niri FullScreen Manager" "Failed to connect to NFSM_SOCKET: $SOCKET" && niri msg action fullscreen-window' ERR
-
     CMD=''${1:-fullscreen}
+
     case "$CMD" in
       fullscreen)
-        echo 'FullscreenRequest' | socat - UNIX-CONNECT:"$SOCKET"
+        NIRI_ACTION="fullscreen-window"
+        SOCKET_CMD="FullscreenRequest"
         ;;
       maximize)
-        echo 'MaximizeRequest' | socat - UNIX-CONNECT:"$SOCKET"
+        NIRI_ACTION="maximize-window-to-edges"
+        SOCKET_CMD="MaximizeRequest"
         ;;
       *)
         echo "Unknown command: $CMD" >&2
         exit 1
         ;;
     esac
+
+    trap 'notify-send --icon="${./assets/icon.png}" --app-name="NFSM" "Niri FullScreen Manager" "Failed to connect to NFSM_SOCKET: $SOCKET" && niri msg action "$NIRI_ACTION"' ERR
+    echo "$SOCKET_CMD" | socat - UNIX-CONNECT:"$SOCKET"
   '';
 
   meta = {

--- a/src/cli.nix
+++ b/src/cli.nix
@@ -9,7 +9,20 @@ writeShellApplication {
   text = ''
     SOCKET=''${NFSM_SOCKET:-/run/user/1000/nfsm.sock}
     trap 'notify-send --icon="${./assets/icon.png}" --app-name="NFSM" "Niri FullScreen Manager" "Failed to connect to NFSM_SOCKET: $SOCKET" && niri msg action fullscreen-window' ERR
-    echo 'FullscreenRequest' | socat - UNIX-CONNECT:"$SOCKET"
+
+    CMD=''${1:-fullscreen}
+    case "$CMD" in
+      fullscreen)
+        echo 'FullscreenRequest' | socat - UNIX-CONNECT:"$SOCKET"
+        ;;
+      maximize)
+        echo 'MaximizeRequest' | socat - UNIX-CONNECT:"$SOCKET"
+        ;;
+      *)
+        echo "Unknown command: $CMD" >&2
+        exit 1
+        ;;
+    esac
   '';
 
   meta = {

--- a/src/nfsm.py
+++ b/src/nfsm.py
@@ -25,17 +25,12 @@ def main():
     except KeyboardInterrupt:
         sys.exit()
 
-def run_fullscreen_cmd(window_id):
+def run_niri_action(action, window_id):
     subprocess.run(
-        ["niri", "msg", "action", "fullscreen-window", "--id", str(window_id)]
+        ["niri", "msg", "action", action, "--id", str(window_id)]
     )
 
-def run_maximize_cmd(window_id):
-    subprocess.run(
-        ["niri", "msg", "action", "maximize-window-to-edges", "--id", str(window_id)]
-    )
-
-def handle_maximize_request():
+def handle_request(tracked_windows, action):
     # get focused window
     props = subprocess.run(
         ["niri", "msg", "--json", "focused-window"],
@@ -44,46 +39,27 @@ def handle_maximize_request():
     )
     window_id = json.loads(props.stdout)["id"]
 
-    # the window is exiting maximize
-    if window_id in maximize_windows:
-        maximize_windows[window_id]["exit"] = True
+    # the window is exiting
+    if window_id in tracked_windows:
+        tracked_windows[window_id]["exit"] = True
         # trigger a niri window layouts changed event
-        run_maximize_cmd(window_id)
+        run_niri_action(action, window_id)
         return
 
-    # the window is entering maximize
+    # the window is entering
     if window_id in window_positions:
         col, row = window_positions[window_id]
-        maximize_windows[window_id] = {
+        tracked_windows[window_id] = {
             "position": (col, row),
             "exit": False
         }
-        run_maximize_cmd(window_id)
+        run_niri_action(action, window_id)
 
 def handle_fullscreen_request():
-    # get focused window
-    props = subprocess.run(
-        ["niri", "msg", "--json", "focused-window"],
-        capture_output=True,
-        text=True,
-    )
-    window_id = json.loads(props.stdout)["id"]
+    handle_request(fullscreen_windows, "fullscreen-window")
 
-    # the window is exiting fullscreen
-    if window_id in fullscreen_windows:
-        fullscreen_windows[window_id]["exit"] = True
-        # trigger a niri window layouts changed event
-        run_fullscreen_cmd(window_id)
-        return
-
-    # the window is entering fullscreen
-    if window_id in window_positions:
-        col, row = window_positions[window_id]
-        fullscreen_windows[window_id] = {
-            "position": (col, row),
-            "exit": False
-        }
-        run_fullscreen_cmd(window_id)
+def handle_maximize_request():
+    handle_request(maximize_windows, "maximize-window-to-edges")
 
 def nfsm_socket():
     server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -134,6 +110,22 @@ def handle_window_closed(window_id):
 
 def niri_cmd(command):
     subprocess.run(["niri", "msg", "action", command])
+
+def restore_position(tracked_windows, window_id, col, row):
+    if window_id not in tracked_windows or not tracked_windows[window_id]["exit"]:
+        return False
+    dest_col, dest_row = tracked_windows[window_id]["position"]
+    # move window to the right column if necessary
+    if dest_col < col:
+        niri_cmd("consume-or-expel-window-left")
+        return True
+    # move window to the correct row if necessary
+    if dest_row != row:
+        for _ in range(row - dest_row):
+            niri_cmd("move-window-up")
+    # window is already back at its last recorded position
+    del tracked_windows[window_id]
+    return False
 
 def nfsm_stream():
     proc = subprocess.Popen(
@@ -195,29 +187,10 @@ def nfsm_stream():
                 continue
 
             # move the window to the last recorded position when necessary
-            if window_id in fullscreen_windows and fullscreen_windows[window_id]["exit"]:
-                dest_col, dest_row = fullscreen_windows[window_id]["position"]
-                # move window to the right column if necessary
-                if dest_col < col:
-                    niri_cmd("consume-or-expel-window-left")
-                    continue
-                # the window is already in the right column, we now need to move it to the correct row
-                if dest_row != row:
-                    for _ in range(row - dest_row):
-                        niri_cmd("move-window-up")
-                # window is already back at its last recorded position
-                del fullscreen_windows[window_id]
-
-            if window_id in maximize_windows and maximize_windows[window_id]["exit"]:
-                dest_col, dest_row = maximize_windows[window_id]["position"]
-                if dest_col < col:
-                    niri_cmd("consume-or-expel-window-left")
-                    continue
-                if dest_row != row:
-                    for _ in range(row - dest_row):
-                        niri_cmd("move-window-up")
-                # window is already back at its last recorded position
-                del maximize_windows[window_id]
+            if restore_position(fullscreen_windows, window_id, col, row):
+                continue
+            if restore_position(maximize_windows, window_id, col, row):
+                continue
 
             window_positions[window_id] = (col, row)
 

--- a/src/nfsm.py
+++ b/src/nfsm.py
@@ -11,6 +11,8 @@ import threading
 window_positions = {}
 # dict that tracks fullscreen windows and their restore positions { window_id -> { position: (col, row), exit: Bool } }
 fullscreen_windows = {}
+# dict that tracks maximized windows and their restore positions { window_id -> { position: (col, row), exit: Bool } }
+maximize_windows = {}
 
 def main():
     t1 = threading.Thread(target=nfsm_stream)
@@ -27,6 +29,36 @@ def run_fullscreen_cmd(window_id):
     subprocess.run(
         ["niri", "msg", "action", "fullscreen-window", "--id", str(window_id)]
     )
+
+def run_maximize_cmd(window_id):
+    subprocess.run(
+        ["niri", "msg", "action", "maximize-window-to-edges", "--id", str(window_id)]
+    )
+
+def handle_maximize_request():
+    # get focused window
+    props = subprocess.run(
+        ["niri", "msg", "--json", "focused-window"],
+        capture_output=True,
+        text=True,
+    )
+    window_id = json.loads(props.stdout)["id"]
+
+    # the window is exiting maximize
+    if window_id in maximize_windows:
+        maximize_windows[window_id]["exit"] = True
+        # trigger a niri window layouts changed event
+        run_maximize_cmd(window_id)
+        return
+
+    # the window is entering maximize
+    if window_id in window_positions:
+        col, row = window_positions[window_id]
+        maximize_windows[window_id] = {
+            "position": (col, row),
+            "exit": False
+        }
+        run_maximize_cmd(window_id)
 
 def handle_fullscreen_request():
     # get focused window
@@ -84,6 +116,8 @@ def nfsm_socket():
                 cmd = data.decode('utf-8').strip()
                 if cmd == "FullscreenRequest":
                     handle_fullscreen_request()
+                elif cmd == "MaximizeRequest":
+                    handle_maximize_request()
         except socket.error as e:
             print(f"Socket error: {e}")
         finally:
@@ -95,6 +129,8 @@ def handle_window_closed(window_id):
         del window_positions[window_id]
     if window_id in fullscreen_windows:
         del fullscreen_windows[window_id]
+    if window_id in maximize_windows:
+        del maximize_windows[window_id]
 
 def niri_cmd(command):
     subprocess.run(["niri", "msg", "action", command])
@@ -171,6 +207,17 @@ def nfsm_stream():
                         niri_cmd("move-window-up")
                 # window is already back at its last recorded position
                 del fullscreen_windows[window_id]
+
+            if window_id in maximize_windows and maximize_windows[window_id]["exit"]:
+                dest_col, dest_row = maximize_windows[window_id]["position"]
+                if dest_col < col:
+                    niri_cmd("consume-or-expel-window-left")
+                    continue
+                if dest_row != row:
+                    for _ in range(row - dest_row):
+                        niri_cmd("move-window-up")
+                # window is already back at its last recorded position
+                del maximize_windows[window_id]
 
             window_positions[window_id] = (col, row)
 

--- a/src/nfsm.py
+++ b/src/nfsm.py
@@ -223,5 +223,9 @@ def nfsm_stream():
 
             sys.stdout.flush()
 
+    proc.wait()
+    if proc.returncode != 0:
+        os._exit(1)
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR enables the `maximize-to-window-edges` niri command to be used with nfsm. This PR also reduces code duplication between the two, also opening up support for other maximize/fullscreen functions.

This PR also allows the daemon to exit if the Niri socket is not available, as before, it would print an error message but never exit. The systemd service is updated to restart on failure, allowing the daemon to restart until the Niri socket is available.

Disclosure: I used Claude code to assist with writing this change.

Resolves: #5 